### PR TITLE
Support guzzlehttp/psr7 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/psr7": "^1.1",
+        "guzzlehttp/psr7": "^1.7|^2",
         "aws/aws-sdk-php": "^3.2"
     },
     "autoload": {

--- a/tests/GzStreamTest.php
+++ b/tests/GzStreamTest.php
@@ -1,13 +1,14 @@
 <?php
-use GuzzleHttp\Psr7;
+
 use Cyberdummy\GzStream\GzStreamGuzzle;
+use GuzzleHttp\Psr7\Utils;
 
 class GzStreamGuzzleTest extends \PHPUnit_Framework_TestCase
 {
     public function testReadStream()
     {
         $content = gzencode('test');
-        $a = Psr7\stream_for($content);
+        $a = Utils::streamFor($content);
         $b = new GzStreamGuzzle($a);
         $this->assertEquals('test', (string) $b);
     }
@@ -16,7 +17,7 @@ class GzStreamGuzzleTest extends \PHPUnit_Framework_TestCase
     {
         $dest = __DIR__.'/writeTest.gz';
         $fh = fopen($dest, 'w');
-        $a = Psr7\stream_for($fh);
+        $a = Utils::streamFor($fh);
         $gzStream = new GzStreamGuzzle($a);
         $content = 'The quick brown fox jumps over the lazy dog';
         $gzStream->write($content);
@@ -33,7 +34,7 @@ class GzStreamGuzzleTest extends \PHPUnit_Framework_TestCase
     {
         $dest = __DIR__.'/closeTest.gz';
         $fh = fopen($dest, 'w');
-        $a = Psr7\stream_for($fh);
+        $a = Utils::streamFor($fh);
         $gzStream = new GzStreamGuzzle($a);
         $content = 'The quick brown fox jumps over the lazy dog';
         $gzStream->write($content);


### PR DESCRIPTION
Hi @cyberdummy. Like we talked at https://github.com/cyberdummy/gzstream/issues/1, here is a PR to support guzzlehttp/psr7. aws/aws-sdk-php already supports it for some time.

I have tried your test cases and their results didn't change.

I hope you can merge & tag new version soon, as I did my best to make changes minimal, although I was itching to update phpunit version and so on, since phpunit 4 doesn't work with modern php versions.